### PR TITLE
fix(core): start route pipeline before consumer to avoid BRPOP startup race

### DIFF
--- a/crates/camel-core/src/lifecycle/adapters/route_controller.rs
+++ b/crates/camel-core/src/lifecycle/adapters/route_controller.rs
@@ -918,16 +918,6 @@ impl RouteController for DefaultRouteController {
             let pre_pipeline = Arc::clone(&split.pre_pipeline);
             let post_pipeline = Arc::clone(&split.post_pipeline);
 
-            // Spawn consumer task (same as normal route)
-            let consumer_handle = super::consumer_management::spawn_consumer_task(
-                route_id.to_string(),
-                consumer,
-                consumer_ctx,
-                crash_notifier,
-                runtime_for_consumer,
-                false,
-            );
-
             // Spawn biased select forward loop
             let pipeline_handle = tokio::spawn(async move {
                 loop {
@@ -1007,6 +997,17 @@ impl RouteController for DefaultRouteController {
                 }
             });
 
+            // Start consumer after pipeline loop is spawned to avoid startup races
+            // where consumers emit exchanges before the route pipeline begins polling.
+            let consumer_handle = super::consumer_management::spawn_consumer_task(
+                route_id.to_string(),
+                consumer,
+                consumer_ctx,
+                crash_notifier,
+                runtime_for_consumer,
+                false,
+            );
+
             let managed = self
                 .routes
                 .get_mut(route_id)
@@ -1019,16 +1020,6 @@ impl RouteController for DefaultRouteController {
             return Ok(());
         }
         // --- End aggregator v2 branch ---
-
-        // Start consumer in background task.
-        let consumer_handle = super::consumer_management::spawn_consumer_task(
-            route_id.to_string(),
-            consumer,
-            consumer_ctx,
-            crash_notifier,
-            runtime_for_consumer,
-            false,
-        );
 
         // Spawn pipeline task with its own cancellation token
         let pipeline_handle = match effective_concurrency {
@@ -1119,6 +1110,17 @@ impl RouteController for DefaultRouteController {
                 })
             }
         };
+
+        // Start consumer after pipeline task is spawned to minimize the chance of
+        // fire-and-forget events being produced before the pipeline loop is active.
+        let consumer_handle = super::consumer_management::spawn_consumer_task(
+            route_id.to_string(),
+            consumer,
+            consumer_ctx,
+            crash_notifier,
+            runtime_for_consumer,
+            false,
+        );
 
         // Store handles and update status
         let managed = self


### PR DESCRIPTION
### Motivation
- BRPOP consumers could dequeue items while downstream pipeline steps never executed in heavy multi-route startup scenarios, indicating a startup ordering race where consumers emit exchanges before the pipeline begins polling.

### Description
- Spawn the route pipeline loop before starting the consumer in the aggregate-with-timeout startup path to avoid races where late pipeline setup misses early exchanges.
- Apply the same ordering change in the standard sequential/concurrent pipeline startup path so the pipeline task is always active before the consumer runs.
- Add inline comments explaining the reasoning for starting the pipeline first to minimize fire-and-forget startup races.

### Testing
- Ran `cargo fmt --all` to format changes successfully.
- Ran `cargo test -p camel-core route_controller_tests -- --nocapture` and the test run completed successfully (all relevant tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2b909eb88321b09acb94fd018b6a)