### PR TITLE
feat(camel-dsl): add JSON route DSL

### DIFF
--- a/crates/camel-cli/README.md
+++ b/crates/camel-cli/README.md
@@ -15,7 +15,7 @@ camel <COMMAND>
 
 Commands:
   new      Scaffold a new Camel project
-  run      Start a Camel context from YAML route files with hot-reload
+  run      Start a Camel context from route files (YAML or JSON) with hot-reload
   journal  Inspect a runtime journal file
   help     Print help
 
@@ -77,18 +77,18 @@ camel run
 
 ## `camel run`
 
-Starts a Camel context and loads routes from YAML files. Hot-reload is **disabled
+Starts a Camel context and loads routes from YAML or JSON files. Hot-reload is **disabled
 by default** — enable it with `--watch` or via `Camel.toml`.
 
 ```bash
 camel run [OPTIONS]
 
 Options:
-  --routes <GLOB>   Glob pattern for route YAML files
-  --config <FILE>   Path to Camel.toml (default: Camel.toml)
-  --watch           Enable file-watcher hot-reload
-  --no-watch        Disable file-watcher hot-reload (overrides Camel.toml)
-  --health-port <PORT>  Override health server port (enables standalone health server)
+   --routes <GLOB>   Glob pattern for route files (default examples use YAML; explicit .json globs also supported)
+   --config <FILE>   Path to Camel.toml (default: Camel.toml)
+   --watch           Enable file-watcher hot-reload
+   --no-watch        Disable file-watcher hot-reload (overrides Camel.toml)
+   --health-port <PORT>  Override health server port (enables standalone health server)
 ```
 
 ### Quick start — no config file
@@ -187,7 +187,7 @@ See [camel-dsl](../crates/camel-dsl) for the full step reference.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `routes` | `[String]` | `[]` | Glob patterns for route YAML files |
+| `routes` | `[String]` | `[]` | Glob patterns for route files (default examples use YAML; explicit `.json` globs are also supported) |
 | `watch` | `bool` | `false` | Enable file-watcher hot-reload |
 | `runtime_journal_path` | `String?` | disabled | Optional flag to enable local runtime durability/replay |
 | `log_level` | `String` | `"INFO"` | Tracing log level |

--- a/crates/camel-config/README.md
+++ b/crates/camel-config/README.md
@@ -30,7 +30,7 @@ Create a `Camel.toml` file in your project root:
 
 ```toml
 [default]
-routes = ["routes/*.yaml"]
+routes = ["routes/*.yaml"]    # Default examples use YAML; explicit .json globs are also supported
 watch = false
 log_level = "info"
 drain_timeout_ms = 10000  # Graceful drain timeout for hot-reload restart/remove (default: 10s)
@@ -123,7 +123,7 @@ allow_private_ips = true  # Allow internal services in dev
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `routes` | `[String]` |  | Glob patterns for route files |
+| `routes` | `[String]` |  | Glob patterns for route files (default examples use YAML; explicit `.json` globs also supported) |
 | `watch` | `bool` |  | Enable hot reload on file changes |
 | `runtime_journal_path` | `String?` |  | Optional durability flag: when set, enables local runtime journal replay |
 | `log_level` | `String` |  | Logging level (trace/debug/info/warn/error) |
@@ -394,7 +394,7 @@ camel-config = "*"
 ## Related Crates
 
 - **camel-core** - Core framework and context
-- **camel-dsl** - YAML route definitions and parsing
+- **camel-dsl** - YAML and JSON route definitions and parsing
 - **camel-runtime** - Route execution engine
 
 ## Documentation

--- a/crates/camel-config/src/context_ext.rs
+++ b/crates/camel-config/src/context_ext.rs
@@ -704,6 +704,34 @@ routes = ["["]
         assert!(matches!(err, CamelError::Config(_)));
     }
 
+    #[test]
+    fn load_routes_with_explicit_json_pattern() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().unwrap();
+        let json_file = dir.path().join("route.json");
+        std::fs::write(
+            &json_file,
+            r#"{"routes":[{"id":"config-json-route","from":"timer:tick","steps":[{"to":"log:info"}]}]}"#,
+        )
+        .unwrap();
+
+        let pattern = dir.path().join("*.json").to_string_lossy().to_string();
+        let mut cfg_file = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            cfg_file,
+            r#"
+routes = ["{}"]
+"#,
+            pattern.replace('\\', "\\\\")
+        )
+        .unwrap();
+
+        let routes = CamelConfig::load_routes(cfg_file.path().to_str().unwrap()).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].route_id(), "config-json-route");
+    }
+
     #[tokio::test]
     async fn configure_context_with_noop_platform_succeeds() {
         let cfg = config::Config::builder()

--- a/crates/camel-config/src/discovery.rs
+++ b/crates/camel-config/src/discovery.rs
@@ -1,43 +1,30 @@
-//! Route discovery module - finds and loads routes from YAML files using glob patterns.
+//! Route discovery module — delegates to [`camel_dsl::discovery`] for YAML and JSON.
 
 use camel_core::route::RouteDefinition;
-use glob::glob;
-use std::fs;
-use std::io;
-
-use crate::yaml::parse_yaml_with_threshold;
 
 /// Errors that can occur during route discovery.
+///
+/// Wraps errors from [`camel_dsl::discovery::DiscoveryError`] with a single
+/// variant to preserve the existing `camel-config` public API.
 #[derive(Debug, thiserror::Error)]
 pub enum DiscoveryError {
-    /// Invalid glob pattern.
-    #[error("Glob pattern error: {0}")]
-    GlobPattern(#[from] glob::PatternError),
-
-    /// Error accessing file while iterating glob.
-    #[error("Glob error accessing {path}: {source}")]
-    GlobAccess { path: String, source: io::Error },
-
-    /// Error reading a file.
-    #[error("IO error reading {path}: {source}")]
-    Io { path: String, source: io::Error },
-
-    /// Error parsing YAML content.
-    #[error("YAML parse error in {path}: {error}")]
-    Yaml { path: String, error: String },
+    /// Error from the underlying DSL discovery (YAML, JSON, glob, env, etc.).
+    #[error("{0}")]
+    Dsl(#[from] camel_dsl::DiscoveryError),
 }
 
-/// Discovers routes from YAML files matching the given glob patterns.
+/// Discovers routes from YAML/JSON files matching the given glob patterns.
+///
+/// Delegates to [`camel_dsl::discover_routes`] which supports:
+/// - `.yaml` / `.yml` — parsed as YAML
+/// - `.json` — parsed as JSON, but only when the glob explicitly targets `.json`
 ///
 /// # Arguments
-/// * `patterns` - Slice of glob patterns to match YAML files
-///
-/// # Returns
-/// A vector of all discovered route definitions, or an error.
+/// * `patterns` - Slice of glob patterns to match route definition files
 ///
 /// # Example
 /// ```ignore
-/// let routes = discover_routes(&["routes/*.yaml".to_string(), "extra/**/*.yaml".to_string()])?;
+/// let routes = discover_routes(&["routes/*.yaml".to_string(), "routes/*.json".to_string()])?;
 /// ```
 pub fn discover_routes(patterns: &[String]) -> Result<Vec<RouteDefinition>, DiscoveryError> {
     discover_routes_with_threshold(
@@ -46,38 +33,16 @@ pub fn discover_routes(patterns: &[String]) -> Result<Vec<RouteDefinition>, Disc
     )
 }
 
+/// Discovers routes with a custom stream-cache threshold.
+///
+/// Same as [`discover_routes`] but compiles routes with the given threshold
+/// instead of the default.
 pub fn discover_routes_with_threshold(
     patterns: &[String],
     stream_cache_threshold: usize,
 ) -> Result<Vec<RouteDefinition>, DiscoveryError> {
-    let mut routes = Vec::new();
-
-    for pattern in patterns {
-        let entries = glob(pattern)?;
-
-        for entry in entries {
-            let path = entry.map_err(|e| DiscoveryError::GlobAccess {
-                path: e.path().to_string_lossy().to_string(),
-                source: e.into_error(),
-            })?;
-            let path_str = path.to_string_lossy().to_string();
-
-            let yaml_content = fs::read_to_string(&path).map_err(|e| DiscoveryError::Io {
-                path: path_str.clone(),
-                source: e,
-            })?;
-
-            let file_routes = parse_yaml_with_threshold(&yaml_content, stream_cache_threshold)
-                .map_err(|e| DiscoveryError::Yaml {
-                    path: path_str,
-                    error: e.to_string(),
-                })?;
-
-            routes.extend(file_routes);
-        }
-    }
-
-    Ok(routes)
+    camel_dsl::discover_routes_with_threshold(patterns, stream_cache_threshold)
+        .map_err(DiscoveryError::from)
 }
 
 #[cfg(test)]
@@ -94,7 +59,11 @@ mod tests {
     #[test]
     fn discover_routes_invalid_glob_returns_pattern_error() {
         let err = discover_routes(&["[".to_string()]).err().unwrap();
-        assert!(matches!(err, DiscoveryError::GlobPattern(_)));
+        assert!(matches!(err, DiscoveryError::Dsl(_)));
+        assert!(
+            err.to_string().contains("Glob pattern"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -110,7 +79,7 @@ mod tests {
         std::os::unix::fs::symlink(dir.path().join("does-not-exist.yaml"), &link_path).unwrap();
 
         let err = discover_routes(&[pattern]).err().unwrap();
-        assert!(matches!(err, DiscoveryError::Io { .. }));
+        assert!(matches!(err, DiscoveryError::Dsl(_)));
     }
 
     #[test]
@@ -121,6 +90,26 @@ mod tests {
         let pattern = dir.path().join("*.yaml").to_string_lossy().to_string();
 
         let err = discover_routes(&[pattern]).err().unwrap();
-        assert!(matches!(err, DiscoveryError::Yaml { .. }));
+        assert!(matches!(err, DiscoveryError::Dsl(_)));
+        assert!(
+            err.to_string().contains("YAML parse error"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn discover_routes_explicit_json_pattern_loads_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("route.json");
+        fs::write(
+            &file_path,
+            r#"{"routes":[{"id":"config-json","from":"direct:start","steps":[{"to":"log:out"}]}]}"#,
+        )
+        .unwrap();
+
+        let pattern = dir.path().join("*.json").to_string_lossy().to_string();
+        let routes = discover_routes(&[pattern]).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].route_id(), "config-json");
     }
 }

--- a/crates/camel-config/tests/context_config_test.rs
+++ b/crates/camel-config/tests/context_config_test.rs
@@ -1,8 +1,9 @@
 use camel_api::{CanonicalRouteSpec, RuntimeCommand};
 use camel_config::config::{
-    CamelConfig, JournalConfig, ObservabilityConfig, OtelCamelConfig, PlatformCamelConfig,
-    StreamCachingConfig,
+    CamelConfig, JournalConfig, PlatformCamelConfig, StreamCachingConfig,
 };
+#[cfg(feature = "otel")]
+use camel_config::config::{ObservabilityConfig, OtelCamelConfig};
 use std::collections::HashMap;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/camel-dsl/Cargo.toml
+++ b/crates/camel-dsl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camel-dsl"
-description = "DSL support for rust-camel (YAML, etc)"
+description = "DSL support for rust-camel (YAML, JSON)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/camel-dsl/README.md
+++ b/crates/camel-dsl/README.md
@@ -1,11 +1,11 @@
 # camel-dsl
 
-> 
-> DSL support for rust-camel (YAML, etc)
+>
+> DSL support for rust-camel (YAML, JSON)
 
 ## Overview
 
-`camel-dsl` provides Domain Specific Language support for defining routes in rust-camel declaratively. Routes can be defined in YAML files and loaded at runtime, enabling external configuration without recompiling the application.
+`camel-dsl` provides Domain Specific Language support for defining routes in rust-camel declaratively. Routes can be defined in YAML or JSON files and loaded at runtime, enabling external configuration without recompiling the application.
 
  This crate is useful when you want to:
 - Externalize route configuration
@@ -14,7 +14,7 @@
 
 ## Features
 
-- **YAML route definitions**: Define routes using YAML syntax
+- **YAML and JSON route definitions**: Define routes using YAML or JSON syntax
 - **Declarative integration flows**: Use all available EIPs and DSL
 - **External configuration**: Load routes from files at runtime
 - **Language expressions**: Use `simple:` and `rhai:` syntax for dynamic values
@@ -126,7 +126,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-camel-dsl = "*"
+camel-dsl = "0.8"
 ```
 
 ## Quick Start
@@ -181,6 +181,72 @@ routes:
             - to: "log:filtered"
 ```
 
+## JSON Route Definitions
+
+JSON route definitions use the same shape as YAML — the only difference is the serialization format. This means all step types, route-level configuration, and language expressions work identically in both formats.
+
+### Example
+
+Create a JSON file `routes.json`:
+
+```json
+{
+  "routes": [
+    {
+      "id": "hello-timer",
+      "from": "timer:tick?period=2000",
+      "steps": [
+        { "log": "Timer fired!" },
+        { "to": "log:info" }
+      ]
+    }
+  ]
+}
+```
+
+### Programmatic Loading
+
+```rust
+// Parse a JSON string directly
+use camel_dsl::parse_json;
+
+let routes = parse_json(&json_string)?;
+
+// Load from a file
+use camel_dsl::json::load_json_from_file;
+use std::path::Path;
+
+let routes = load_json_from_file(Path::new("routes.json"))?;
+```
+
+The type aliases `JsonRoutes`, `JsonRoute`, and `JsonStep` are convenience wrappers around the YAML AST types and are **not a stable SDK contract**. SDKs and external consumers that need forward compatibility should target `CanonicalRouteSpec` instead:
+
+```rust
+use camel_dsl::parse_json_to_canonical;
+
+let specs = parse_json_to_canonical(&json_string)?;
+```
+
+### Discovery Behavior
+
+When using [`discover_routes`] to load route files via glob patterns, **JSON files require an explicit `.json` glob pattern**. Broad patterns like `routes/*` will intentionally not load `.json` files — this prevents accidental loading from mixed-format directories.
+
+```rust
+use camel_dsl::discover_routes;
+
+// ✅ Explicit .json pattern — loads JSON files
+let routes = discover_routes(&["routes/*.json".to_string()])?;
+
+// ❌ Broad pattern — will NOT load .json files (returns an error if any are matched)
+let routes = discover_routes(&["routes/*".to_string()])?;
+
+// Mixing both formats in one call is fine:
+let routes = discover_routes(&[
+    "routes/*.yaml".to_string(),
+    "routes/*.json".to_string(),
+])?;
+```
+
 ## Available Step Types
 
 | Step | Description | Example |
@@ -189,7 +255,7 @@ routes:
 | `log` | Log message | `- log: "Processing"` |
 | `set_header` | Set header | `- set_header: { key: "x", value: "y" }` |
 | `set_body` | Set body | `- set_body: { value: "content" }` |
-| `transform` | Transform body (alias for `set_body`) | `- transform: { simple: "${body}" }` |
+| `transform` | Transform body | `- transform: { simple: "${body}" }` |
 | `marshal` | Serialize body using a data format (e.g., Json → Text) | `- marshal: json` |
 | `unmarshal` | Deserialize body using a data format (e.g., Text → Json) | `- unmarshal: xml` |
 | `filter` | Filter messages | `- filter: { simple: "${header.type} == 'allowed'", steps: [...] }` |
@@ -280,7 +346,7 @@ routes:
 
 ## Environment Variable Interpolation
 
-Use `${env:VAR_NAME}` anywhere in a YAML route file to inject an environment variable at load time:
+Use `${env:VAR_NAME}` anywhere in a route file to inject an environment variable at load time. This works for both YAML and JSON formats when loaded via [`discover_routes`]:
 
 ```yaml
 routes:
@@ -291,7 +357,9 @@ routes:
       - to: "${env:OUTPUT_ENDPOINT}"
 ```
 
-The substitution happens before YAML parsing, so it works in any position — URIs, log messages, header values, etc. Unset variables are left as-is (the literal `${env:VAR_NAME}` string).
+The substitution happens before parsing, so it works in any position — URIs, log messages, header values, etc. If an environment variable is not set and no default is provided via the `:-` syntax, discovery returns a `DiscoveryError::Env` error — the literal `${env:VAR_NAME}` string is **not** left in place.
+
+> **Caution:** Because interpolation is textual (performed before parsing), env values injected into JSON string positions must already be valid for their JSON context. For example, an env var containing an unescaped double quote will produce invalid JSON, causing a `DiscoveryError::Json` parse error. YAML is more forgiving of unquoted values but the same principle applies to structured contexts.
 
 You can specify a default value when the variable is not set:
 
@@ -305,6 +373,8 @@ routes:
 ```
 
 If `POLL_MS` is not set, the default `1000` is used. The `:-` syntax follows the same convention as shell parameter expansion.
+
+> **Note:** Direct file loaders (`load_from_file` for YAML, `json::load_json_from_file` for JSON) read and parse files without interpolating environment variables. Use [`discover_routes`] if you need env interpolation.
 
 ## Language Expressions
 Many steps support language expressions for dynamic values:

--- a/crates/camel-dsl/src/discovery.rs
+++ b/crates/camel-dsl/src/discovery.rs
@@ -528,10 +528,8 @@ mod tests {
         )
         .unwrap();
 
-        let pattern = f.path().to_string_lossy().to_string();
-        // Need an explicit .json pattern since the temp file has .json suffix
-        let json_pattern = f.path().with_extension("json").to_string_lossy().to_string();
         // The temp file path IS the pattern (already ends in .json)
+        let pattern = f.path().to_string_lossy().to_string();
         let err = match discover_routes(&[pattern]) {
             Ok(_) => panic!("expected JSON parse error"),
             Err(e) => e,

--- a/crates/camel-dsl/src/discovery.rs
+++ b/crates/camel-dsl/src/discovery.rs
@@ -1,4 +1,4 @@
-//! Route discovery module - finds and loads routes from YAML files using glob patterns.
+//! Route discovery module - finds and loads routes from YAML/JSON files using glob patterns.
 
 use camel_core::route::RouteDefinition;
 use glob::glob;
@@ -6,12 +6,15 @@ use std::collections::hash_map::DefaultHasher;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io;
+use std::path::Path;
 
 use crate::env_interpolation::interpolate_env;
-use crate::yaml::parse_yaml;
+use crate::json::{parse_json, parse_json_with_threshold};
+use crate::yaml::{parse_yaml, parse_yaml_with_threshold};
 
 /// Errors that can occur during route discovery.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum DiscoveryError {
     /// Invalid glob pattern.
     #[error("Glob pattern error: {0}")]
@@ -28,25 +31,82 @@ pub enum DiscoveryError {
     /// Error parsing YAML content.
     #[error("YAML parse error in {path}: {error}")]
     Yaml { path: String, error: String },
+
+    /// Environment variable not set during interpolation.
+    #[error("Environment variable '{var_name}' not set (required by {path})")]
+    Env { path: String, var_name: String },
+
+    /// Error parsing JSON content.
+    #[error("JSON parse error in {path}: {error}")]
+    Json { path: String, error: String },
+
+    /// File has an unsupported extension (not .yaml, .yml, or .json).
+    #[error("Unsupported file extension '{extension}' in {path}")]
+    UnsupportedExtension { path: String, extension: String },
+
+    /// JSON file matched by a broad glob pattern requires an explicit .json pattern.
+    #[error("JSON file {path} matched by broad pattern '{pattern}' — use an explicit .json glob like 'routes/*.json'")]
+    JsonRequiresExplicitPattern { path: String, pattern: String },
 }
 
-/// Discovers routes from YAML files matching the given glob patterns.
+/// Returns true if the glob pattern explicitly targets `.json` files.
+///
+/// Only patterns whose **file target extension** is `.json` (case-insensitive) return true.
+/// A `.json` segment appearing only in a directory path (e.g. `config/.json/routes/*`)
+/// does **not** authorize JSON loading.
+fn pattern_targets_json(pattern: &str) -> bool {
+    let lower = pattern.to_lowercase();
+    // Extract the last path segment (the file/target portion) and check if it ends with .json
+    lower
+        .rsplit('/')
+        .next()
+        .is_some_and(|last_segment| last_segment.ends_with(".json"))
+}
+
+/// Extracts the lowercase file extension from a path, if any.
+fn file_extension(path: &Path) -> Option<String> {
+    path.extension().map(|ext| ext.to_string_lossy().to_lowercase())
+}
+
+/// Discovers routes from YAML/JSON files matching the given glob patterns.
 ///
 /// # Arguments
-/// * `patterns` - Slice of glob patterns to match YAML files
+/// * `patterns` - Slice of glob patterns to match route definition files
 ///
 /// # Returns
 /// A vector of all discovered route definitions, or an error.
 ///
+/// # Supported formats
+/// - `.yaml` / `.yml` — parsed as YAML
+/// - `.json` — parsed as JSON, but only when the source pattern explicitly targets `.json`
+///
 /// # Example
 /// ```ignore
-/// let routes = discover_routes(&["routes/*.yaml".to_string(), "extra/**/*.yaml".to_string()])?;
+/// let routes = discover_routes(&["routes/*.yaml".to_string(), "routes/*.json".to_string()])?;
 /// ```
 pub fn discover_routes(patterns: &[String]) -> Result<Vec<RouteDefinition>, DiscoveryError> {
+    discover_routes_inner(patterns, None)
+}
+
+/// Discovers routes with a custom stream-cache threshold.
+///
+/// Same as [`discover_routes`] but uses the given `stream_cache_threshold`
+/// instead of the default when compiling routes.
+pub fn discover_routes_with_threshold(
+    patterns: &[String],
+    stream_cache_threshold: usize,
+) -> Result<Vec<RouteDefinition>, DiscoveryError> {
+    discover_routes_inner(patterns, Some(stream_cache_threshold))
+}
+
+fn discover_routes_inner(
+    patterns: &[String],
+    stream_cache_threshold: Option<usize>,
+) -> Result<Vec<RouteDefinition>, DiscoveryError> {
     let mut routes = Vec::new();
 
     for pattern in patterns {
-        // glob returns an iterator over matching paths
+        let is_json_pattern = pattern_targets_json(pattern);
         let entries = glob(pattern)?;
 
         for entry in entries {
@@ -56,30 +116,98 @@ pub fn discover_routes(patterns: &[String]) -> Result<Vec<RouteDefinition>, Disc
             })?;
             let path_str = path.to_string_lossy().to_string();
 
-            // Read file content
-            let yaml_content = fs::read_to_string(&path).map_err(|e| DiscoveryError::Io {
+            // Validate extension and JSON explicit-pattern gate BEFORE reading or
+            // interpolating — rejects must not trigger env lookups.
+            let ext = file_extension(&path);
+            match ext.as_deref() {
+                Some("yaml") | Some("yml") => {}
+                Some("json") => {
+                    if !is_json_pattern {
+                        return Err(DiscoveryError::JsonRequiresExplicitPattern {
+                            path: path_str,
+                            pattern: pattern.clone(),
+                        });
+                    }
+                }
+                Some(other) => {
+                    return Err(DiscoveryError::UnsupportedExtension {
+                        path: path_str,
+                        extension: other.to_string(),
+                    });
+                }
+                None => {
+                    return Err(DiscoveryError::UnsupportedExtension {
+                        path: path_str,
+                        extension: String::new(),
+                    });
+                }
+            }
+
+            // Read file content (only reached for accepted extensions)
+            let raw_content = fs::read_to_string(&path).map_err(|e| DiscoveryError::Io {
                 path: path_str.clone(),
                 source: e,
             })?;
 
+            // Source hash is based on raw content before env interpolation
             let mut hasher = DefaultHasher::new();
-            yaml_content.hash(&mut hasher);
+            raw_content.hash(&mut hasher);
             let source_hash = hasher.finish();
 
-            let yaml_content =
-                interpolate_env(&yaml_content).map_err(|var_name| DiscoveryError::Yaml {
-                    path: path_str.clone(),
-                    error: format!("Environment variable '{var_name}' is not set"),
-                })?;
-
-            // Parse YAML into route definitions
-            let file_routes = parse_yaml(&yaml_content).map_err(|e| DiscoveryError::Yaml {
-                path: path_str,
-                error: e.to_string(),
+            // Env interpolation happens before parsing for both YAML and JSON.
+            // NOTE: interpolation is textual — env values used inside JSON string
+            // positions must already be valid/escaped for JSON context, otherwise
+            // the subsequent JSON parse will fail with a DiscoveryError::Json.
+            let content = interpolate_env(&raw_content).map_err(|var_name| DiscoveryError::Env {
+                path: path_str.clone(),
+                var_name,
             })?;
 
-            for route in file_routes {
-                routes.push(route.with_source_hash(source_hash));
+            // Parse based on accepted extension — no fallback arm needed because
+            // the validation block above guarantees only yaml/yml/json reach here.
+            match ext.as_deref() {
+                Some("yaml") | Some("yml") => {
+                    let file_routes = match stream_cache_threshold {
+                        Some(threshold) => {
+                            parse_yaml_with_threshold(&content, threshold)
+                                .map_err(|e| DiscoveryError::Yaml {
+                                    path: path_str,
+                                    error: e.to_string(),
+                                })?
+                        }
+                        None => parse_yaml(&content).map_err(|e| DiscoveryError::Yaml {
+                            path: path_str,
+                            error: e.to_string(),
+                        })?,
+                    };
+                    for route in file_routes {
+                        routes.push(route.with_source_hash(source_hash));
+                    }
+                }
+                Some("json") => {
+                    let file_routes = match stream_cache_threshold {
+                        Some(threshold) => {
+                            parse_json_with_threshold(&content, threshold)
+                                .map_err(|e| DiscoveryError::Json {
+                                    path: path_str,
+                                    error: e.to_string(),
+                                })?
+                        }
+                        None => parse_json(&content).map_err(|e| DiscoveryError::Json {
+                            path: path_str,
+                            error: e.to_string(),
+                        })?,
+                    };
+                    for route in file_routes {
+                        routes.push(route.with_source_hash(source_hash));
+                    }
+                }
+                // SAFETY: Unreachable. The validation block above returns early for
+                // any extension that is not yaml, yml, or json.
+                _ => unreachable!(
+                    "validated extension should be yaml/yml/json but was: {:?}",
+                    ext
+                ),
             }
         }
     }
@@ -94,11 +222,67 @@ mod tests {
     use std::io::Write;
     use tempfile::NamedTempFile;
 
+    // ── pattern_targets_json ──────────────────────────────────────────
+
     #[test]
-    fn discovers_route_with_env_var_in_uri() {
+    fn pattern_targets_json_explicit() {
+        assert!(pattern_targets_json("routes/*.json"));
+    }
+
+    #[test]
+    fn pattern_targets_json_recursive() {
+        assert!(pattern_targets_json("routes/**/*.json"));
+    }
+
+    #[test]
+    fn pattern_targets_json_uppercase() {
+        assert!(pattern_targets_json("routes/*.JSON"));
+    }
+
+    #[test]
+    fn pattern_targets_json_with_trailing_slash() {
+        // .json in directory name but file targets .json — should still match
+        assert!(pattern_targets_json("config/.json/routes/*.json"));
+    }
+
+    #[test]
+    fn pattern_targets_json_dir_name_only_returns_false() {
+        // .json only appears in directory path, not as file extension
+        assert!(!pattern_targets_json("config/.json/routes/*"));
+    }
+
+    #[test]
+    fn pattern_targets_json_dir_name_recursive_returns_false() {
+        assert!(!pattern_targets_json("config/.json/routes/**/*"));
+    }
+
+    #[test]
+    fn pattern_targets_json_brace_expansion() {
+        assert!(pattern_targets_json("routes/{a,b}.json"));
+    }
+
+    #[test]
+    fn pattern_targets_json_uppercase_extension() {
+        assert!(pattern_targets_json("routes/*.JSON"));
+    }
+
+    #[test]
+    fn pattern_targets_json_broad_returns_false() {
+        assert!(!pattern_targets_json("routes/*"));
+    }
+
+    #[test]
+    fn pattern_targets_json_broad_recursive_returns_false() {
+        assert!(!pattern_targets_json("routes/**/*"));
+    }
+
+    // ── YAML discovery ───────────────────────────────────────────────
+
+    #[test]
+    fn discovers_route_with_env_var_in_uri_yaml() {
         unsafe { env::set_var("TEST_DISC_TIMER_NAME", "my-tick") };
 
-        let mut f = NamedTempFile::new().unwrap();
+        let mut f = NamedTempFile::with_suffix(".yaml").unwrap();
         writeln!(f, "routes:").unwrap();
         writeln!(f, "  - id: \"disc-route-1\"").unwrap();
         writeln!(f, "    from: \"timer:${{env:TEST_DISC_TIMER_NAME}}\"").unwrap();
@@ -114,10 +298,10 @@ mod tests {
     }
 
     #[test]
-    fn discover_fails_when_env_var_missing() {
+    fn discover_fails_when_env_var_missing_yaml() {
         unsafe { env::remove_var("TEST_DISC_MISSING_VAR") };
 
-        let mut f = NamedTempFile::new().unwrap();
+        let mut f = NamedTempFile::with_suffix(".yaml").unwrap();
         writeln!(f, "routes:").unwrap();
         writeln!(f, "  - id: \"disc-route-missing\"").unwrap();
         writeln!(f, "    from: \"timer:${{env:TEST_DISC_MISSING_VAR}}\"").unwrap();
@@ -125,13 +309,274 @@ mod tests {
 
         let pattern = f.path().to_string_lossy().to_string();
         let err = match discover_routes(&[pattern]) {
-            Ok(_) => panic!("expected discover_routes to fail"),
-            Err(err) => err,
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
         };
-        let msg = err.to_string();
-        assert!(
-            msg.contains("TEST_DISC_MISSING_VAR"),
-            "error should mention var name, got: {msg}"
-        );
+        match &err {
+            DiscoveryError::Env { path: _, var_name } => {
+                assert_eq!(var_name, "TEST_DISC_MISSING_VAR");
+            }
+            other => panic!("expected Env error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn discovers_yml_extension() {
+        let mut f = NamedTempFile::with_suffix(".yml").unwrap();
+        writeln!(f, "routes:").unwrap();
+        writeln!(f, "  - id: \"yml-route\"").unwrap();
+        writeln!(f, "    from: \"timer:tick\"").unwrap();
+        writeln!(f, "    steps:").unwrap();
+        writeln!(f, "      - to: \"log:info\"").unwrap();
+
+        let pattern = f.path().to_string_lossy().to_string();
+        let routes = discover_routes(&[pattern]).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].route_id(), "yml-route");
+    }
+
+    // ── JSON discovery ───────────────────────────────────────────────
+
+    #[test]
+    fn discovers_explicit_json_route() {
+        let mut f = NamedTempFile::with_suffix(".json").unwrap();
+        write!(
+            f,
+            r#"{{
+  "routes": [
+    {{
+      "id": "json-route-1",
+      "from": "timer:tick?period=1000",
+      "steps": [
+        {{ "to": "log:info" }}
+      ]
+    }}
+  ]
+}}"#
+        )
+        .unwrap();
+
+        let pattern = f.path().to_string_lossy().to_string();
+        let routes = discover_routes(&[pattern]).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].route_id(), "json-route-1");
+        assert_eq!(routes[0].from_uri(), "timer:tick?period=1000");
+    }
+
+    #[test]
+    fn discovers_json_with_glob_pattern() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("route.json");
+        fs::write(
+            &file_path,
+            r#"{"routes":[{"id":"glob-json","from":"direct:start","steps":[{"to":"log:out"}]}]}"#,
+        )
+        .unwrap();
+
+        let pattern = dir.path().join("*.json").to_string_lossy().to_string();
+        let routes = discover_routes(&[pattern]).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].route_id(), "glob-json");
+    }
+
+    // ── Extension/gate validation before env interpolation ────────────
+
+    #[test]
+    fn unsupported_extension_with_env_var_returns_unsupported_not_env() {
+        // .xml file containing a real env var reference must fail with
+        // UnsupportedExtension, NOT Env — env interpolation must not run.
+        unsafe { env::remove_var("TASK3_SHOULD_NOT_READ_ENV") };
+
+        let f = NamedTempFile::with_suffix(".xml").unwrap();
+        let content = "content: ${env:TASK3_SHOULD_NOT_READ_ENV}";
+        fs::write(f.path(), content).unwrap();
+
+        let pattern = f.path().to_string_lossy().to_string();
+        let err = match discover_routes(&[pattern]) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        match &err {
+            DiscoveryError::UnsupportedExtension { path: _, extension } => {
+                assert_eq!(extension, "xml");
+            }
+            other => panic!(
+                "expected UnsupportedExtension, got: {:?} — env interpolation ran before extension check",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn broad_glob_json_with_missing_env_returns_gate_not_env() {
+        // Broad glob matching .json with missing env var must fail with
+        // JsonRequiresExplicitPattern, NOT Env — gate must fire before interpolation.
+        unsafe { env::remove_var("TASK3_SHOULD_NOT_READ_ENV") };
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("route.json");
+        fs::write(
+            &file_path,
+            r#"{"routes":[{"id":"x","from":"timer:${env:TASK3_SHOULD_NOT_READ_ENV}","steps":[]}]}"#,
+        )
+        .unwrap();
+
+        let pattern = dir.path().join("*").to_string_lossy().to_string();
+        let err = match discover_routes(&[pattern]) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        match &err {
+            DiscoveryError::JsonRequiresExplicitPattern { path: p, pattern: pat } => {
+                assert!(p.ends_with("route.json"), "path was: {p}");
+                assert!(!pat.contains(".json"), "pattern was: {pat}");
+            }
+            other => panic!(
+                "expected JsonRequiresExplicitPattern, got: {:?} — gate did not fire before env interpolation",
+                other
+            ),
+        }
+    }
+
+    // ── Unsupported extension ────────────────────────────────────────
+
+    #[test]
+    fn unsupported_extension_returns_error() {
+        let mut f = NamedTempFile::with_suffix(".xml").unwrap();
+        writeln!(f, "<routes/>").unwrap();
+
+        let pattern = f.path().to_string_lossy().to_string();
+        let err = match discover_routes(&[pattern]) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        match &err {
+            DiscoveryError::UnsupportedExtension { path: _, extension } => {
+                assert_eq!(extension, "xml");
+            }
+            other => panic!("expected UnsupportedExtension, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_extension_returns_error() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "routes:").unwrap();
+
+        let pattern = f.path().to_string_lossy().to_string();
+        let err = match discover_routes(&[pattern]) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        match &err {
+            DiscoveryError::UnsupportedExtension { path: _, extension } => {
+                assert!(extension.is_empty());
+            }
+            other => panic!("expected UnsupportedExtension, got: {other:?}"),
+        }
+    }
+
+    // ── Broad glob rejects JSON ──────────────────────────────────────
+
+    #[test]
+    fn broad_glob_rejects_json_with_explicit_pattern_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("route.json");
+        fs::write(
+            &file_path,
+            r#"{"routes":[{"id":"broad-json","from":"direct:start","steps":[]}]}"#,
+        )
+        .unwrap();
+
+        // Use a broad pattern that matches .json files but doesn't explicitly target .json
+        let pattern = dir.path().join("*").to_string_lossy().to_string();
+        let err = match discover_routes(&[pattern]) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        match &err {
+            DiscoveryError::JsonRequiresExplicitPattern { path: p, pattern: pat } => {
+                assert!(p.ends_with("route.json"), "path was: {p}");
+                assert!(pat.ends_with('*'), "pattern was: {pat}");
+                assert!(!pat.contains(".json"), "pattern was: {pat}");
+            }
+            other => panic!("expected JsonRequiresExplicitPattern, got: {other:?}"),
+        }
+    }
+
+    // ── JSON env interpolation ────────────────────────────────────────────
+
+    #[test]
+    fn json_env_interpolation_with_unescaped_quote_returns_json_error() {
+        // An env var containing a raw double-quote will break JSON parsing
+        // because interpolation is textual — the quote is injected verbatim
+        // into the JSON string, producing invalid JSON.
+        unsafe { env::set_var("TEST_JSON_BAD_QUOTE", r#"has"quote"#) };
+
+        let mut f = NamedTempFile::with_suffix(".json").unwrap();
+        write!(
+            f,
+            r#"{{
+  "routes": [
+    {{
+      "id": "bad-quote",
+      "from": "timer:${{env:TEST_JSON_BAD_QUOTE}}",
+      "steps": []
+    }}
+  ]
+}}"#
+        )
+        .unwrap();
+
+        let pattern = f.path().to_string_lossy().to_string();
+        // Need an explicit .json pattern since the temp file has .json suffix
+        let json_pattern = f.path().with_extension("json").to_string_lossy().to_string();
+        // The temp file path IS the pattern (already ends in .json)
+        let err = match discover_routes(&[pattern]) {
+            Ok(_) => panic!("expected JSON parse error"),
+            Err(e) => e,
+        };
+        match &err {
+            DiscoveryError::Json { path: _, error } => {
+                // Error should mention the parse failure (caused by unescaped quote)
+                assert!(
+                    !error.is_empty(),
+                    "JSON parse error should describe the issue"
+                );
+            }
+            other => panic!(
+                "expected DiscoveryError::Json, got: {:?}",
+                other
+            ),
+        }
+
+        unsafe { env::remove_var("TEST_JSON_BAD_QUOTE") };
+    }
+
+    #[test]
+    fn json_env_interpolation_with_valid_value_succeeds() {
+        unsafe { env::set_var("TEST_JSON_GOOD_VAL", "tick") };
+
+        let mut f = NamedTempFile::with_suffix(".json").unwrap();
+        write!(
+            f,
+            r#"{{
+  "routes": [
+    {{
+      "id": "good-env",
+      "from": "timer:${{env:TEST_JSON_GOOD_VAL}}",
+      "steps": []
+    }}
+  ]
+}}"#
+        )
+        .unwrap();
+
+        let pattern = f.path().to_string_lossy().to_string();
+        let routes = discover_routes(&[pattern]).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].from_uri(), "timer:tick");
+
+        unsafe { env::remove_var("TEST_JSON_GOOD_VAL") };
     }
 }

--- a/crates/camel-dsl/src/json.rs
+++ b/crates/camel-dsl/src/json.rs
@@ -1,0 +1,378 @@
+//! JSON route definition parser.
+//!
+//! Reuses the same AST types as the YAML parser ([`crate::yaml::YamlRoutes`],
+//! [`crate::yaml::YamlRoute`], [`crate::yaml::YamlStep`])
+//! since JSON is a subset of YAML's data model. The only difference is the deserializer.
+//!
+//! ## Stability note
+//!
+//! The type aliases [`JsonRoutes`], [`JsonRoute`], [`JsonStep`] are convenience wrappers
+//! around the YAML AST types. They are **not a stable SDK contract**. SDKs and external
+//! consumers should target [`CanonicalRouteSpec`] for forward compatibility.
+
+use std::path::Path;
+
+use camel_api::{CamelError, CanonicalRouteSpec};
+use camel_core::route::RouteDefinition;
+
+use crate::compile::{
+    compile_declarative_route, compile_declarative_route_to_canonical,
+    compile_declarative_route_with_stream_cache_threshold,
+};
+use crate::yaml::{yaml_route_to_declarative_route, YamlRoutes};
+
+/// Convenience alias — not a stable SDK contract. Target [`CanonicalRouteSpec`] instead.
+pub type JsonRoutes = crate::yaml::YamlRoutes;
+
+/// Convenience alias — not a stable SDK contract. Target [`CanonicalRouteSpec`] instead.
+pub type JsonRoute = crate::yaml::YamlRoute;
+
+/// Convenience alias — not a stable SDK contract. Target [`CanonicalRouteSpec`] instead.
+pub type JsonStep = crate::yaml::YamlStep;
+
+/// Parse a JSON string into declarative route models.
+pub fn parse_json_to_declarative(
+    json: &str,
+) -> Result<Vec<crate::model::DeclarativeRoute>, CamelError> {
+    let routes: YamlRoutes = serde_json::from_str(json)
+        .map_err(|e| CamelError::RouteError(format!("JSON parse error: {e}")))?;
+
+    routes
+        .routes
+        .into_iter()
+        .map(yaml_route_to_declarative_route)
+        .collect()
+}
+
+/// Parse a JSON string into compiled [`RouteDefinition`]s.
+pub fn parse_json(json: &str) -> Result<Vec<RouteDefinition>, CamelError> {
+    parse_json_to_declarative(json)?
+        .into_iter()
+        .map(compile_declarative_route)
+        .collect()
+}
+
+/// Parse a JSON string with a custom stream-cache threshold.
+pub fn parse_json_with_threshold(
+    json: &str,
+    stream_cache_threshold: usize,
+) -> Result<Vec<RouteDefinition>, CamelError> {
+    parse_json_to_declarative(json)?
+        .into_iter()
+        .map(|route| {
+            compile_declarative_route_with_stream_cache_threshold(route, stream_cache_threshold)
+        })
+        .collect()
+}
+
+/// Parse a JSON string into canonical route specs.
+pub fn parse_json_to_canonical(
+    json: &str,
+) -> Result<Vec<CanonicalRouteSpec>, CamelError> {
+    parse_json_to_declarative(json)?
+        .into_iter()
+        .map(compile_declarative_route_to_canonical)
+        .collect()
+}
+
+/// Load a JSON route definition from a file.
+///
+/// Reads the file contents and parses them as JSON. No environment variable interpolation is performed.
+pub fn load_json_from_file(path: &Path) -> Result<Vec<RouteDefinition>, CamelError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| CamelError::Io(format!("Failed to read {}: {e}", path.display())))?;
+    parse_json(&content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::DeclarativeStep;
+
+    /// Basic route: parse JSON to declarative model.
+    #[test]
+    fn test_basic_route_to_declarative() {
+        let json = r#"
+        {
+            "routes": [
+                {
+                    "id": "test-route",
+                    "from": "timer:tick?period=1000",
+                    "steps": [
+                        {"set_header": {"key": "source", "value": "timer"}},
+                        {"to": "log:info"}
+                    ]
+                }
+            ]
+        }"#;
+        let routes = parse_json_to_declarative(json).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].route_id, "test-route");
+        assert_eq!(routes[0].from, "timer:tick?period=1000");
+        assert_eq!(routes[0].steps.len(), 2);
+    }
+
+    /// Route metadata: auto_startup and startup_order round-trip correctly.
+    #[test]
+    fn test_route_metadata_auto_startup_and_startup_order() {
+        let json = r#"
+        {
+            "routes": [
+                {
+                    "id": "meta-route",
+                    "from": "direct:start",
+                    "auto_startup": false,
+                    "startup_order": 42
+                }
+            ]
+        }"#;
+        let routes = parse_json_to_declarative(json).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert!(!routes[0].auto_startup);
+        assert_eq!(routes[0].startup_order, 42);
+    }
+
+    /// Error handler with on_exceptions including handled_by.
+    #[test]
+    fn test_error_handler_with_handled_by() {
+        let json = r#"
+        {
+            "routes": [
+                {
+                    "id": "eh-route",
+                    "from": "direct:start",
+                    "error_handler": {
+                        "dead_letter_channel": "log:dlc",
+                        "on_exceptions": [
+                            {
+                                "kind": "Io",
+                                "retry": {
+                                    "max_attempts": 3,
+                                    "handled_by": "log:io"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }"#;
+        let routes = parse_json_to_declarative(json).unwrap();
+        let eh = routes[0]
+            .error_handler
+            .as_ref()
+            .expect("error handler should be present");
+        let clauses = eh
+            .on_exceptions
+            .as_ref()
+            .expect("on_exceptions should be present");
+        assert_eq!(clauses.len(), 1);
+        assert_eq!(clauses[0].kind.as_deref(), Some("Io"));
+        let retry = clauses[0].retry.as_ref().expect("retry should be present");
+        assert_eq!(retry.max_attempts, 3);
+        assert_eq!(retry.handled_by.as_deref(), Some("log:io"));
+    }
+
+    /// Empty route id must be rejected.
+    #[test]
+    fn test_empty_id_fails() {
+        let json = r#"
+        {
+            "routes": [
+                {
+                    "id": "",
+                    "from": "timer:tick"
+                }
+            ]
+        }"#;
+        let result = parse_json_to_declarative(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("route 'id' must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Invalid JSON must produce an error containing "JSON".
+    #[test]
+    fn test_invalid_json_error_says_json() {
+        let json = "{ not valid json }}}";
+        let result = parse_json_to_declarative(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("JSON parse error:"),
+            "expected 'JSON parse error:' in error, got: {err}"
+        );
+    }
+
+    /// Compiled route via parse_json produces a RouteDefinition.
+    #[test]
+    fn test_compiled_route_via_parse_json() {
+        let json = r#"
+        {
+            "routes": [
+                {
+                    "id": "compiled-route",
+                    "from": "timer:tick",
+                    "steps": [
+                        {"to": "log:info"}
+                    ]
+                }
+            ]
+        }"#;
+        let defs = parse_json(json).unwrap();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].route_id(), "compiled-route");
+        assert_eq!(defs[0].from_uri(), "timer:tick");
+    }
+
+    /// parse_json_with_threshold compiles routes with custom stream-cache threshold.
+    #[test]
+    fn test_threshold_parse() {
+        let json = r#"
+        {
+            "routes": [
+                {
+                    "id": "threshold-route",
+                    "from": "timer:tick",
+                    "steps": [
+                        {"stream_cache": true},
+                        {"to": "log:info"}
+                    ]
+                }
+            ]
+        }"#;
+        let defs = parse_json_with_threshold(json, 8192).unwrap();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].route_id(), "threshold-route");
+    }
+
+    /// Canonical conversion via parse_json_to_canonical.
+    #[test]
+    fn test_canonical_conversion() {
+        let json = r#"
+        {
+            "routes": [
+                {
+                    "id": "canonical-v1",
+                    "from": "direct:start",
+                    "steps": [
+                        {"to": "mock:out"},
+                        {"log": {"message": "hello"}},
+                        {"stop": true}
+                    ]
+                }
+            ]
+        }"#;
+        let routes = parse_json_to_canonical(json).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].route_id, "canonical-v1");
+        assert_eq!(routes[0].from, "direct:start");
+        assert_eq!(routes[0].version, 1);
+        assert_eq!(routes[0].steps.len(), 3);
+    }
+
+    /// The "loop" step JSON key works.
+    #[test]
+    fn test_loop_step_json_key() {
+        let json = r#"
+        {
+            "routes": [
+                {
+                    "id": "loop-route",
+                    "from": "direct:start",
+                    "steps": [
+                        {"loop": 3}
+                    ]
+                }
+            ]
+        }"#;
+        let routes = parse_json_to_declarative(json).unwrap();
+        assert_eq!(routes.len(), 1);
+        match &routes[0].steps[0] {
+            DeclarativeStep::Loop(def) => {
+                assert_eq!(def.count, Some(3));
+            }
+            other => panic!("expected Loop step, got {:?}", other),
+        }
+    }
+
+    /// Multiple routes in a single JSON document.
+    #[test]
+    fn test_multiple_routes() {
+        let json = r#"
+        {
+            "routes": [
+                {
+                    "id": "route-a",
+                    "from": "timer:tick",
+                    "steps": [{"to": "log:info"}]
+                },
+                {
+                    "id": "route-b",
+                    "from": "timer:tock",
+                    "auto_startup": false,
+                    "startup_order": 10
+                }
+            ]
+        }"#;
+        let defs = parse_json(json).unwrap();
+        assert_eq!(defs.len(), 2);
+        assert_eq!(defs[0].route_id(), "route-a");
+        assert_eq!(defs[1].route_id(), "route-b");
+    }
+
+    /// Defaults: auto_startup=true, startup_order=1000 when omitted.
+    #[test]
+    fn test_defaults() {
+        let json = r#"
+        {
+            "routes": [
+                {
+                    "id": "default-route",
+                    "from": "timer:tick"
+                }
+            ]
+        }"#;
+        let defs = parse_json(json).unwrap();
+        assert!(defs[0].auto_startup());
+        assert_eq!(defs[0].startup_order(), 1000);
+    }
+
+    /// File loading via load_json_from_file.
+    #[test]
+    fn test_file_loading() {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+
+        let json_content = r#"
+        {
+            "routes": [
+                {
+                    "id": "file-route",
+                    "from": "timer:tick",
+                    "steps": [{"to": "log:info"}]
+                }
+            ]
+        }"#;
+
+        file.write_all(json_content.as_bytes()).unwrap();
+
+        let defs = load_json_from_file(file.path()).unwrap();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].route_id(), "file-route");
+    }
+
+    /// Missing file must return an error.
+    #[test]
+    fn test_missing_file_error() {
+        let result = load_json_from_file(Path::new("/nonexistent/path/routes.json"));
+        assert!(result.is_err());
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("Failed to read"),
+            "expected file read error, got: {err}"
+        );
+    }
+}

--- a/crates/camel-dsl/src/lib.rs
+++ b/crates/camel-dsl/src/lib.rs
@@ -2,6 +2,7 @@ pub mod compile;
 pub mod contract;
 pub mod discovery;
 pub mod env_interpolation;
+pub mod json;
 pub mod model;
 pub mod yaml;
 pub mod yaml_ast;
@@ -11,7 +12,10 @@ pub use compile::{
     compile_declarative_route_with_stream_cache_threshold, compile_declarative_step,
 };
 pub use contract::{DeclarativeStepKind, is_rust_only_kind, mandatory_declarative_step_kinds};
-pub use discovery::{DiscoveryError, discover_routes};
+pub use discovery::{DiscoveryError, discover_routes, discover_routes_with_threshold};
+pub use json::{
+    parse_json, parse_json_to_canonical, parse_json_to_declarative, parse_json_with_threshold,
+};
 pub use model::{
     AggregateStepDef, AggregateStrategyDef, BodyTypeDef, ChoiceStepDef, DeclarativeCircuitBreaker,
     DeclarativeConcurrency, DeclarativeErrorHandler, DeclarativeRedeliveryPolicy, DeclarativeRoute,

--- a/crates/camel-dsl/src/yaml.rs
+++ b/crates/camel-dsl/src/yaml.rs
@@ -96,7 +96,7 @@ pub fn parse_yaml_to_canonical(yaml: &str) -> Result<Vec<CanonicalRouteSpec>, Ca
         .collect()
 }
 
-fn yaml_route_to_declarative_route(route: YamlRoute) -> Result<DeclarativeRoute, CamelError> {
+pub(crate) fn yaml_route_to_declarative_route(route: YamlRoute) -> Result<DeclarativeRoute, CamelError> {
     if route.id.is_empty() {
         return Err(CamelError::RouteError(
             "route 'id' must not be empty".into(),
@@ -181,7 +181,7 @@ fn yaml_route_to_declarative_route(route: YamlRoute) -> Result<DeclarativeRoute,
     })
 }
 
-fn yaml_step_to_declarative_step(step: YamlStep) -> Result<DeclarativeStep, CamelError> {
+pub(crate) fn yaml_step_to_declarative_step(step: YamlStep) -> Result<DeclarativeStep, CamelError> {
     match step {
         YamlStep::To(ToStep { to }) => Ok(DeclarativeStep::To(ToStepDef::new(to))),
         YamlStep::WireTap(WireTapStep { wire_tap }) => {


### PR DESCRIPTION
## Summary
- Add first-class JSON route DSL parsing with canonical/declarative APIs alongside YAML.
- Share discovery through `camel-dsl` so explicit `.json` route globs work through `camel-config` and CLI/config paths while YAML remains the default.
- Tighten JSON discovery gating, document env interpolation behavior, and add JSON discovery/config tests.

## Test Plan
- [x] `cargo test -p camel-dsl`
- [x] `cargo test -p camel-config`
- [x] `cargo check -p camel-cli`
- [x] `cargo check --workspace`
- [x] `cargo doc -p camel-dsl --no-deps`
- [x] `cargo clippy -p camel-dsl -- -D warnings`
- [x] `cargo clippy -p camel-config -- -D warnings`

## Reviews
- [x] Expert review found no Critical/Important issues after fixes
- [x] Closure review verified all prior minor/residual risks are closed