### PR TITLE
chore(dev): add Codespaces environment

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,12 +1,12 @@
 # GitHub Codespaces
 
 Create a codespace from the repository as usual. The container installs Nix,
-OpenCode, and an SSH server, then evaluates the project's pinned development
-shell once so its dependencies are cached.
+Neovim, OpenCode, and an SSH server, then evaluates the project's pinned
+development shell once so its dependencies are cached.
 
 Enter the development shell before building:
 
-```console
+```sh
 nix develop
 ```
 
@@ -16,9 +16,22 @@ OpenCode is installed in the user profile and is available directly:
 opencode
 ```
 
+A Neovim config is copied to `~/.config/nvim` on first setup. It is built on
+`mini.nvim` with LazyVim-style keybindings (pinned via `lazy-lock.json`,
+pre-warmed during setup). `rg` is installed for `mini.pick` grep.
+
+Finders/explorer (`mini.pick` / `mini.files`):
+- `<leader><space>` / `<leader>ff` find files, `<leader>fg` live grep
+- `<leader>fb` / `<leader>,` buffers, `<leader>:` command history
+- `<leader>e` file explorer
+
+Terminals (`toggleterm`) float centered at 80% of the editor: `<C-1>`..`<C-9>`
+(or `<leader>t1`..`<leader>t9`) toggle terminals 1-9; `<C-\>` / `<leader>tt`
+toggle terminal 1.
+
 GitHub's authenticated SSH path does not require exposing a port:
 
-```console
+```sh
 gh codespace ssh --codespace <name>
 ```
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,27 @@
+# GitHub Codespaces
+
+Create a codespace from the repository as usual. The container installs Nix,
+OpenCode, and an SSH server, then evaluates the project's pinned development
+shell once so its dependencies are cached.
+
+Enter the development shell before building:
+
+```console
+nix develop
+```
+
+OpenCode is installed in the user profile and is available directly:
+
+```console
+opencode
+```
+
+GitHub's authenticated SSH path does not require exposing a port:
+
+```console
+gh codespace ssh --codespace <name>
+```
+
+The SSH daemon feature is also present for clients that need a conventional
+daemon. Prefer `gh codespace ssh`, which uses Codespaces authentication and
+does not require managing a public SSH port.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "rust-camel",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/nix:1": {
+      "extraNixConfig": "experimental-features = nix-command flakes"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {}
+  },
+  "postCreateCommand": ".devcontainer/setup.sh",
+  "remoteUser": "vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "jnoortheen.nix-ide",
+        "rust-lang.rust-analyzer"
+      ]
+    }
+  }
+}

--- a/.devcontainer/nvim/init.lua
+++ b/.devcontainer/nvim/init.lua
@@ -1,0 +1,21 @@
+vim.g.mapleader = " "
+vim.g.maplocalleader = " "
+
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.uv.fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable",
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+require("lazy").setup("plugins", {
+  install = { missing = true },
+  checker = { enabled = false },
+  change_detection = { notify = false },
+})

--- a/.devcontainer/nvim/lazy-lock.json
+++ b/.devcontainer/nvim/lazy-lock.json
@@ -1,0 +1,8 @@
+{
+  "gitsigns.nvim": { "branch": "main", "commit": "31d6fb2d618bca1482b9f274751ead5f03461408" },
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "mini.nvim": { "branch": "main", "commit": "bcb4b2688b38f5c48ada025abe130d41840e11d5" },
+  "nvim-treesitter": { "branch": "master", "commit": "cf12346a3414fa1b06af75c79faebe7f76df080a" },
+  "toggleterm.nvim": { "branch": "main", "commit": "50ea089fc548917cc3cc16b46a8211833b9e3c7c" },
+  "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" }
+}

--- a/.devcontainer/nvim/lua/plugins/colors.lua
+++ b/.devcontainer/nvim/lua/plugins/colors.lua
@@ -1,0 +1,10 @@
+return {
+  {
+    "folke/tokyonight.nvim",
+    lazy = false,
+    priority = 1000,
+    config = function()
+      vim.cmd.colorscheme("tokyonight-night")
+    end,
+  },
+}

--- a/.devcontainer/nvim/lua/plugins/gitsigns.lua
+++ b/.devcontainer/nvim/lua/plugins/gitsigns.lua
@@ -1,0 +1,32 @@
+return {
+  {
+    "lewis6991/gitsigns.nvim",
+    event = { "BufReadPre", "BufNewFile" },
+    config = function()
+      require("gitsigns").setup({
+        signs = {
+          add = { text = "+" },
+          change = { text = "~" },
+          delete = { text = "_" },
+          topdelete = { text = "‾" },
+          changedelete = { text = "~" },
+        },
+      })
+      local function map(mode, lhs, rhs, desc)
+        vim.keymap.set(mode, lhs, rhs, { desc = desc })
+      end
+      map("n", "]h", "<cmd>Gitsigns next_hunk<cr>", "Next hunk")
+      map("n", "[h", "<cmd>Gitsigns prev_hunk<cr>", "Prev hunk")
+      map({ "n", "v" }, "<leader>ghs", ":Gitsigns stage_hunk<cr>", "Stage hunk")
+      map({ "n", "v" }, "<leader>ghr", ":Gitsigns reset_hunk<cr>", "Reset hunk")
+      map("n", "<leader>ghS", "<cmd>Gitsigns stage_buffer<cr>", "Stage buffer")
+      map("n", "<leader>ghu", "<cmd>Gitsigns undo_stage_hunk<cr>", "Undo stage hunk")
+      map("n", "<leader>ghR", "<cmd>Gitsigns reset_buffer<cr>", "Reset buffer")
+      map("n", "<leader>ghp", "<cmd>Gitsigns preview_hunk<cr>", "Preview hunk")
+      map("n", "<leader>ghb", "<cmd>Gitsigns blame_line<cr>", "Blame line")
+      map("n", "<leader>ghd", "<cmd>Gitsigns diffthis<cr>", "Diff this")
+      map("n", "<leader>gb", "<cmd>Gitsigns toggle_current_line_blame<cr>", "Toggle line blame")
+      map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<cr>", "Git hunk")
+    end,
+  },
+}

--- a/.devcontainer/nvim/lua/plugins/mini.lua
+++ b/.devcontainer/nvim/lua/plugins/mini.lua
@@ -1,0 +1,77 @@
+return {
+  {
+    "echasnovski/mini.nvim",
+    version = false,
+    config = function()
+      local clues = {}
+      local function map(mode, lhs, rhs, desc)
+        vim.keymap.set(mode, lhs, rhs, { desc = desc })
+        table.insert(clues, { mode = mode, keys = lhs, desc = desc })
+      end
+
+      require("mini.basics").setup({
+        options = { basic = true, extra_ui = true, win_borders = "rounded" },
+        mappings = { basic = true, option_toggle = true, windows = true, move_with_alt = true },
+        autocommands = { relnum_in_visual_mode = true },
+      })
+
+      require("mini.ai").setup()
+      require("mini.surround").setup()
+      require("mini.comment").setup()
+      require("mini.pairs").setup()
+      require("mini.icons").setup()
+      require("mini.bracketed").setup()
+      require("mini.indentscope").setup({ symbol = "│" })
+      require("mini.statusline").setup({ use_icons = true })
+      require("mini.tabline").setup()
+
+      require("mini.files").setup()
+      map("n", "<leader>e", "<cmd>lua MiniFiles.open()<cr>", "File explorer")
+      map("n", "<leader>fe", "<cmd>lua MiniFiles.open()<cr>", "File explorer")
+
+      require("mini.pick").setup()
+      require("mini.extra").setup()
+      map("n", "<leader><space>", "<cmd>Pick files<cr>", "Find files")
+      map("n", "<leader>ff", "<cmd>Pick files<cr>", "Find files")
+      map("n", "<leader>fg", "<cmd>Pick grep_live<cr>", "Grep")
+      map("n", "<leader>fb", "<cmd>Pick buffers<cr>", "Buffers")
+      map("n", "<leader>,", "<cmd>Pick buffers<cr>", "Switch buffer")
+      map("n", "<leader>:", "<cmd>Pick command_history<cr>", "Command history")
+
+      require("mini.git").setup()
+      map("n", "<leader>gs", "<cmd>Git status<cr>", "Git status")
+      map("n", "<leader>gl", "<cmd>Git log --oneline<cr>", "Git log")
+      map("n", "<leader>gf", "<cmd>Pick git_files<cr>", "Git files")
+      map("n", "<leader>gc", "<cmd>Pick git_commits<cr>", "Git commits")
+      map("n", "<leader>gB", "<cmd>Pick git_branches<cr>", "Git branches")
+
+      require("mini.clue").setup({
+        window = { config = { anchor = "SW" } },
+        triggers = {
+          { mode = "n", keys = "<leader>" },
+          { mode = "x", keys = "<leader>" },
+          { mode = "n", keys = "g" },
+          { mode = "x", keys = "g" },
+          { mode = "n", keys = "'" },
+          { mode = "n", keys = "`" },
+          { mode = "n", keys = '"' },
+          { mode = "n", keys = "<C-w>" },
+          { mode = "n", keys = "z" },
+        },
+        clues = {
+          require("mini.clue").gen_clues.builtin_completion(),
+          require("mini.clue").gen_clues.g("g"),
+          require("mini.clue").gen_clues.marks(),
+          require("mini.clue").gen_clues.registers(),
+          require("mini.clue").gen_clues.windows(),
+          require("mini.clue").gen_clues.z(),
+          { mode = "n", keys = "<leader>f", desc = "+file/find" },
+          { mode = "n", keys = "<leader>g", desc = "+git" },
+          { mode = "n", keys = "<leader>gh", desc = "+git/hunk" },
+          { mode = "n", keys = "<leader>t", desc = "+terminal" },
+          { mode = "x", keys = "<leader>f", desc = "+file/find" },
+        },
+      })
+    end,
+  },
+}

--- a/.devcontainer/nvim/lua/plugins/toggleterm.lua
+++ b/.devcontainer/nvim/lua/plugins/toggleterm.lua
@@ -1,0 +1,45 @@
+local terminals = {}
+
+local function toggle_terminal(i)
+  local Terminal = require("toggleterm.terminal").Terminal
+  terminals[i] = terminals[i] or Terminal:new({
+    id = i,
+    display_name = "term-" .. i,
+    direction = "float",
+  })
+  terminals[i]:toggle()
+end
+
+return {
+  {
+    "akinsho/toggleterm.nvim",
+    version = "*",
+    opts = {
+      open_mapping = [[<C-\>]],
+      direction = "float",
+      shade_terminals = true,
+      float_opts = {
+        border = "curved",
+        width = function()
+          return math.floor(vim.o.columns * 0.8)
+        end,
+        height = function()
+          return math.floor(vim.o.lines * 0.8)
+        end,
+      },
+    },
+    config = function(_, opts)
+      require("toggleterm").setup(opts)
+      vim.keymap.set("t", "<S-Esc>", [[<C-\><C-n>]], { desc = "Exit terminal mode" })
+      vim.keymap.set({ "n", "t" }, "<leader>tt", "<cmd>ToggleTerm<CR>", { desc = "Toggle terminal" })
+      for i = 1, 9 do
+        vim.keymap.set({ "n", "t" }, "<C-" .. i .. ">", function()
+          toggle_terminal(i)
+        end, { desc = "Toggle terminal " .. i })
+        vim.keymap.set("n", "<leader>t" .. i, function()
+          toggle_terminal(i)
+        end, { desc = "Toggle terminal " .. i })
+      end
+    end,
+  },
+}

--- a/.devcontainer/nvim/lua/plugins/treesitter.lua
+++ b/.devcontainer/nvim/lua/plugins/treesitter.lua
@@ -1,0 +1,34 @@
+return {
+  {
+    "nvim-treesitter/nvim-treesitter",
+    branch = "master",
+    build = ":TSUpdate",
+    config = function()
+      require("nvim-treesitter.configs").setup({
+        ensure_installed = {
+          "rust",
+          "toml",
+          "lua",
+          "vim",
+          "vimdoc",
+          "query",
+          "bash",
+          "markdown",
+          "markdown_inline",
+          "json",
+          "yaml",
+        },
+        sync_install = false,
+        auto_install = true,
+        highlight = { enable = true, disable = { "markdown", "markdown_inline" } },
+        indent = { enable = true, disable = { "markdown", "markdown_inline" } },
+      })
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = { "markdown", "markdown.mdx" },
+        callback = function(args)
+          pcall(vim.treesitter.stop, args.buf)
+        end,
+      })
+    end,
+  },
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if ! command -v opencode >/dev/null 2>&1; then
+  nix profile install .#opencode
+fi
+
+nix develop --command true

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -3,8 +3,32 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+if [ ! -d "$HOME/.config/nvim" ]; then
+  mkdir -p "$HOME/.config"
+  cp -r .devcontainer/nvim "$HOME/.config/nvim"
+fi
+
+if ! command -v nvim >/dev/null 2>&1; then
+  case "$(uname -m)" in
+    x86_64) nvim_arch=x86_64 ;;
+    aarch64 | arm64) nvim_arch=arm64 ;;
+    *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+  esac
+  nvim_url="https://github.com/neovim/neovim/releases/download/v0.12.4/nvim-linux-${nvim_arch}.tar.gz"
+  curl -fsSL "$nvim_url" -o /tmp/nvim.tar.gz
+  sudo tar -xzf /tmp/nvim.tar.gz -C /usr/local --strip-components=1
+  rm /tmp/nvim.tar.gz
+fi
+
+if ! command -v rg >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y ripgrep
+fi
+
 if ! command -v opencode >/dev/null 2>&1; then
   nix profile install .#opencode
 fi
+
+nix develop --command bash -c 'nvim --headless "+Lazy! sync" "+TSInstallSync rust toml lua vim vimdoc query bash markdown markdown_inline json yaml" +qa' >/dev/null 2>&1 || true
 
 nix develop --command true

--- a/flake.nix
+++ b/flake.nix
@@ -137,8 +137,11 @@
             export RUSTC_WRAPPER=sccache
             sccache --stop-server 2>/dev/null || true
             sccache --start-server
-            # export CARGO_TARGET_DIR="$HOME/.cache/rust-camel-target"
-            export CARGO_TARGET_DIR="/home/shared/rust-camel-target"
+            if [ -d "/home/shared" ] && [ -w "/home/shared" ]; then
+              export CARGO_TARGET_DIR="/home/shared/rust-camel-target"
+            else
+              export CARGO_TARGET_DIR="$HOME/.cache/rust-camel-target"
+            fi
 
             # JMS bridge: auto-detect native binary
             BRIDGE_BIN="$PWD/bridges/jms/build/native/jms-bridge"

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,10 @@
           );
         };
 
-        packages.default = rust-camel;
+        packages = {
+          default = rust-camel;
+          opencode = pkgsUnstable.opencode;
+        };
 
         apps.default = flake-utils.lib.mkApp {
           drv = rust-camel;
@@ -119,6 +122,7 @@
             libxml2
             libclang
             pkgsUnstable.beads # agents memory
+            pkgsUnstable.opencode
             pkgsUnstable.rdkafka
             (writeShellScriptBin "openspec" ''
               exec npx @fission-ai/openspec@1.7.0 "$@"


### PR DESCRIPTION
### Motivation

- Provide a minimal, reproducible Codespaces developer environment with Nix flakes and OpenCode so contributors can open the repo quickly and reproducibly. 
- Enable SSH access in Codespaces while preferring `gh codespace ssh` for authenticated access. 

### Description

- Add a Codespaces configuration at `.devcontainer/devcontainer.json` that uses Ubuntu 24.04, enables the Nix feature and an SSH daemon feature, and installs VS Code extensions for Nix and Rust. 
- Add `.devcontainer/setup.sh` which installs the pinned `opencode` flake into the user profile (if missing) and evaluates the project's `nix develop` devshell to cache dependencies. 
- Add `.devcontainer/README.md` documenting entering the Nix shell, using `opencode`, and preferred SSH access via `gh codespace ssh`. 
- Update `flake.nix` to expose `opencode` in the flake `packages` and include `pkgsUnstable.opencode` in the `devShells.default.packages` list so OpenCode is available inside the devshell. 

### Testing

- Ran `cargo fmt --check --all` and it succeeded. 
- Ran `git diff --check` and it succeeded with no issues. 
- Validated JSON with `python3 -m json.tool .devcontainer/devcontainer.json` and it succeeded. 
- Syntax-checked the setup script with `bash -n .devcontainer/setup.sh` and it succeeded. 
- Note: `bd ready --json` was not available in the runner (`bd` not installed) but will be available inside the configured Nix devshell.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f41b968d08321823480917ea0a18f)