### PR TITLE
Add mdBook guide, CI validation, and Pages deployment (Closes #34)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Documentation
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - "examples/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - "examples/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/docs.yml"
+
+permissions:
+  contents: read
+
+env:
+  RUSTDOCFLAGS: "-D warnings"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install documentation tools
+        uses: taiki-e/install-action@eba66cc6f87204a1e73f96e528e759b6c1fcf573 # cargo-binstall
+        with:
+          tool: mdbook@0.4.52,lychee@0.20.1
+      - name: Build Rustdoc
+        run: cargo doc --workspace --no-deps
+      - name: Test Rustdoc examples
+        run: cargo test --workspace --doc
+      - name: Compile guide Rust examples
+        run: cargo check -p hello-world -p config-basic
+      - name: Validate guide YAML examples
+        run: cargo test -p camel-dsl --test documentation_examples
+      - name: Build and test guide
+        run: |
+          mdbook build docs
+          mdbook test docs
+      - name: Check rendered guide links
+        run: lychee --offline --no-progress docs/book

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,9 +40,23 @@ jobs:
         with:
           tool: mdbook@0.4.52,lychee@0.20.1
       - name: Build Rustdoc
-        run: cargo doc --workspace --no-deps
+        run: |
+          cargo doc \
+            -p camel-api \
+            -p camel-core \
+            -p camel-builder \
+            -p camel-dsl \
+            -p camel-endpoint \
+            --no-deps
       - name: Test Rustdoc examples
-        run: cargo test --workspace --doc
+        run: |
+          cargo test \
+            -p camel-api \
+            -p camel-core \
+            -p camel-builder \
+            -p camel-dsl \
+            -p camel-endpoint \
+            --doc
       - name: Compile guide Rust examples
         run: cargo check -p hello-world -p config-basic
       - name: Validate guide YAML examples

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,49 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - "examples/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install mdBook
+        uses: taiki-e/install-action@eba66cc6f87204a1e73f96e528e759b6c1fcf573 # cargo-binstall
+        with:
+          tool: mdbook@0.4.52
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Build guide
+        run: mdbook build docs
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/book
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 docs/*
 !docs/adr
 !docs/benchmarks
+!docs/book.toml
+!docs/src/
+!docs/src/**
 docs/adr/*
 !docs/adr/*.md
 bridges/*/build/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Patterns (EIP) without a JVM — every processor and producer is a
 ## Table of Contents
 
 - [What is rust-camel?](#what-is-rust-camel)
+- [Documentation](#documentation)
 - [Quick Start](#quick-start)
 - [Core Concepts](#core-concepts)
 - [Components & EIP Patterns](#components--eip-patterns)
@@ -83,6 +84,15 @@ shape of the problem.
 - Your workload is pure request/response **without** routing, EIP patterns, or
   multi-system orchestration (a plain web framework is simpler).
 
+## Documentation
+
+- **[Guide](https://kennycallado.github.io/rust-camel/)** — concepts,
+  tutorials, recipes, and operations.
+- **[API reference](https://docs.rs/camel-api/)** — public Rust types, traits,
+  methods, and contracts.
+- **[Examples](examples/)** — runnable Rust and YAML integrations in this
+  repository.
+
 ## Quick Start
 
 ### Run an example
@@ -95,48 +105,10 @@ cargo run -p hello-world
 
 A route receives an `Exchange` from `timer:tick` and sends it to `log:info`.
 
-### Your first route (Rust)
-
-```rust
-use camel_api::{CamelError, Value};
-use camel_builder::{RouteBuilder, StepAccumulation};
-use camel_component_log::LogComponent;
-use camel_component_timer::TimerComponent;
-use camel_core::context::CamelContext;
-
-#[tokio::main]
-async fn main() -> Result<(), CamelError> {
-    tracing_subscriber::fmt::init();
-
-    let mut ctx = CamelContext::builder().build().await?;
-    ctx.register_component(TimerComponent::new());
-    ctx.register_component(LogComponent::new());
-
-    let route = RouteBuilder::from("timer:tick?period=1000&repeatCount=5")
-        .set_header("source", Value::String("timer".into()))
-        .to("log:info?showHeaders=true")
-        .build()?;
-
-    ctx.add_route_definition(route).await?;
-    ctx.start().await?;
-    tokio::signal::ctrl_c().await.ok();
-    ctx.stop().await?;
-    Ok(())
-}
-```
-
-### Your first route (YAML)
-
-```yaml
-# routes/hello.yaml
-routes:
-  - id: "hello-timer"
-    from: "timer:tick?period=1000"
-    steps:
-      - to: "log:info"
-```
-
-Save it as `routes/hello.yaml` and run with `camel run`.
+Follow the guide to build your [first route in
+Rust](https://kennycallado.github.io/rust-camel/getting-started/rust-route.html)
+or [first route in
+YAML](https://kennycallado.github.io/rust-camel/getting-started/yaml-route.html).
 
 ### Use the CLI
 

--- a/crates/camel-api/src/component_metadata.rs
+++ b/crates/camel-api/src/component_metadata.rs
@@ -165,8 +165,8 @@ impl ComponentMetadata {
 
     /// Build a minimal metadata entry for `scheme`.
     ///
-    /// Sets `schema_version` to [`SCHEMA_VERSION`].  The `version` field is
-    /// left empty — components that override [`Component::metadata`] should
+    /// Sets `schema_version` to [`Self::SCHEMA_VERSION`].  The `version` field is
+    /// left empty — components that override `Component::metadata` should
     /// supply their own `env!("CARGO_PKG_VERSION")`.
     pub fn minimal(scheme: &str) -> Self {
         Self {

--- a/crates/camel-core/src/lifecycle/adapters/route_compiler.rs
+++ b/crates/camel-core/src/lifecycle/adapters/route_compiler.rs
@@ -200,7 +200,7 @@ pub fn compose_traced_pipeline(
 
 /// Compose a list of `CompiledStep` items into a single pipeline with body coercion.
 ///
-/// Each processor is optionally wrapped with [`BodyCoercingProcessor`] based on its
+/// Each processor is optionally wrapped with `BodyCoercingProcessor` based on its
 /// contract. Processors with `None` contract are passed through with zero overhead.
 /// `CompiledStep::Stop` passes through without coercion.
 pub fn compose_pipeline_with_contracts(

--- a/crates/camel-core/src/lifecycle/adapters/route_controller.rs
+++ b/crates/camel-core/src/lifecycle/adapters/route_controller.rs
@@ -235,7 +235,7 @@ impl DefaultRouteController {
 
     /// Set the crash notifier for supervision.
     ///
-    /// When set, the controller will send a [`CrashNotification`] whenever
+    /// When set, the controller will send a `CrashNotification` whenever
     /// a consumer crashes.
     pub fn set_crash_notifier(&mut self, tx: mpsc::Sender<CrashNotification>) {
         self.crash_notifier = Some(tx);

--- a/crates/camel-dsl/tests/documentation_examples.rs
+++ b/crates/camel-dsl/tests/documentation_examples.rs
@@ -1,0 +1,13 @@
+use std::{fs, path::PathBuf};
+
+#[test]
+fn guide_yaml_route_uses_the_real_parser() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/config-basic/routes/hello.yaml");
+    let yaml = fs::read_to_string(path).expect("guide YAML example must be readable");
+
+    let routes = camel_dsl::parse_yaml(&yaml).expect("guide YAML example must parse");
+
+    assert_eq!(routes.len(), 1);
+    assert_eq!(routes[0].route_id(), "hello-timer");
+}

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,13 @@
+[book]
+authors = ["rust-camel contributors"]
+language = "en"
+multilingual = false
+src = "src"
+title = "rust-camel Guide"
+
+[build]
+build-dir = "book"
+
+[output.html]
+git-repository-url = "https://github.com/kennycallado/rust-camel"
+site-url = "/rust-camel/"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,16 @@
+# Summary
+
+- [Introduction](introduction.md)
+- [Getting started](getting-started/index.md)
+  - [Installation](getting-started/installation.md)
+  - [First route in Rust](getting-started/rust-route.md)
+  - [First route in YAML](getting-started/yaml-route.md)
+- [Core concepts](concepts/index.md)
+- [EIP patterns](eip/index.md)
+- [Components](components/index.md)
+- [YAML DSL](yaml-dsl/index.md)
+- [Operations](operations/index.md)
+- [Extending rust-camel](extending/index.md)
+- [Architecture](architecture/index.md)
+- [API reference](api-reference.md)
+- [Documentation workflow](contributing.md)

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -1,0 +1,13 @@
+# API reference
+
+The guide does not duplicate public type and method documentation. Use the
+published Rustdoc pages instead:
+
+- [`camel-api`](https://docs.rs/camel-api/) — exchanges, messages, errors, and
+  core contracts
+- [`camel-core`](https://docs.rs/camel-core/) — runtime context and route
+  lifecycle
+- [`camel-builder`](https://docs.rs/camel-builder/) — fluent Rust route builder
+- [`camel-dsl`](https://docs.rs/camel-dsl/) — declarative route parsing
+
+Each component crate also links to its docs.rs page from its package metadata.

--- a/docs/src/architecture/index.md
+++ b/docs/src/architecture/index.md
@@ -1,0 +1,11 @@
+# Architecture
+
+rust-camel separates a Tower-native data plane from a control plane that owns
+route lifecycle and integrations. The repository's
+[`CONTEXT-MAP.md`](https://github.com/kennycallado/rust-camel/blob/main/CONTEXT-MAP.md)
+defines the bounded contexts and domain language; architecture decision
+records under `docs/adr/` explain consequential choices.
+
+The guide is organized by user tasks rather than workspace crates. This keeps
+the narrative stable as internal crate boundaries evolve and leaves public
+type-level contracts to Rustdoc.

--- a/docs/src/components/index.md
+++ b/docs/src/components/index.md
@@ -1,0 +1,6 @@
+# Components
+
+Components connect routes to external systems and own URI schemes such as
+`timer:`, `log:`, `http:`, `file:`, and `kafka:`. An embedded application
+registers the components it uses; the CLI assembles components for declarative
+routes. Component crate APIs are listed in the [API reference](../api-reference.md).

--- a/docs/src/concepts/index.md
+++ b/docs/src/concepts/index.md
@@ -1,0 +1,15 @@
+# Core concepts
+
+- A **route** connects one inbound endpoint to an ordered processing pipeline.
+- An **exchange** carries the input and output messages, properties, and error
+  state through that pipeline.
+- An **endpoint** is a configured address such as `timer:tick` or `log:info`.
+- A **component** owns an endpoint URI scheme and creates its endpoints,
+  consumers, and producers.
+- A **processor** transforms or inspects an exchange. An **Enterprise
+  Integration Pattern (EIP)** composes processing behavior such as choice,
+  split, aggregate, retry, or filtering.
+
+Consumers create exchanges and submit them to routes. Each step receives the
+current exchange, and producers deliver it to outbound endpoints. Components
+must be registered with the context before routes using their schemes start.

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,0 +1,21 @@
+# Documentation workflow
+
+The README is the concise project landing page, this book provides narrative
+guidance, docs.rs hosts API contracts, and runnable examples are the preferred
+source for Rust and YAML snippets.
+
+Use named `ANCHOR` regions and mdBook `include` directives when a snippet can
+come from a real example. Before submitting documentation changes, run:
+
+```console
+mdbook build docs
+mdbook test docs
+cargo check -p hello-world -p config-basic
+cargo test -p camel-dsl --test documentation_examples
+```
+
+The Pages workflow publishes `docs/book` from `main`; generated HTML is not
+committed. A repository administrator must select **GitHub Actions** as the
+Pages build source once in **Settings → Pages**. The structure leaves the
+output directory disposable so future release-versioned books can be staged
+without changing source chapter URLs.

--- a/docs/src/eip/index.md
+++ b/docs/src/eip/index.md
@@ -1,0 +1,7 @@
+# EIP patterns
+
+Enterprise Integration Patterns describe reusable routing and transformation
+behaviors. rust-camel provides patterns such as choice, split, aggregate,
+filter, retry, circuit breaker, and load balancing. Start with the runnable
+[`examples`](https://github.com/kennycallado/rust-camel/tree/main/examples)
+while this section grows into pattern-focused recipes.

--- a/docs/src/extending/index.md
+++ b/docs/src/extending/index.md
@@ -1,0 +1,7 @@
+# Extending rust-camel
+
+Applications can add processors, components, languages, data formats, and
+services. Begin with the
+[`custom-component-bundle`](https://github.com/kennycallado/rust-camel/tree/main/examples/custom-component-bundle)
+example and consult the [API reference](../api-reference.md) for public trait
+contracts.

--- a/docs/src/getting-started/index.md
+++ b/docs/src/getting-started/index.md
@@ -1,0 +1,5 @@
+# Getting started
+
+Install the CLI or add the framework crates to a Rust application, then choose
+the [Rust builder](rust-route.md) or [YAML DSL](yaml-route.md) for your first
+route.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,0 +1,22 @@
+# Installation
+
+rust-camel requires Rust 1.89 or newer. To work with the repository examples:
+
+```console
+git clone https://github.com/kennycallado/rust-camel.git
+cd rust-camel
+cargo run -p hello-world
+```
+
+For declarative routes, install the command-line application:
+
+```console
+cargo install camel-cli
+camel new my-integration
+cd my-integration
+camel run
+```
+
+When embedding rust-camel, add only the crates for the core, builder, and
+components your application uses. The examples' `Cargo.toml` files are the
+most reliable dependency templates while the project remains pre-release.

--- a/docs/src/getting-started/rust-route.md
+++ b/docs/src/getting-started/rust-route.md
@@ -1,0 +1,13 @@
+# First route in Rust
+
+The runnable [`hello-world`](https://github.com/kennycallado/rust-camel/tree/main/examples/hello-world)
+example registers timer and log components, builds a route, and starts its
+context. The code below is included from that compiled workspace example:
+
+```rust,ignore
+{{#include ../../../examples/hello-world/src/main.rs:first-route}}
+```
+
+`timer:tick` is the consumer endpoint. Each tick creates an exchange, the
+route adds a header, and `log:info` receives the exchange as the producer
+endpoint. Run it with `cargo run -p hello-world`.

--- a/docs/src/getting-started/yaml-route.md
+++ b/docs/src/getting-started/yaml-route.md
@@ -1,0 +1,13 @@
+# First route in YAML
+
+The same route shape can be declared without compiling application-specific
+Rust. This snippet is included from the `config-basic` example and is parsed
+by rust-camel's YAML DSL tests:
+
+```yaml
+{{#include ../../../examples/config-basic/routes/hello.yaml:first-route}}
+```
+
+The top-level `routes` list contains route definitions. `from` identifies the
+consumer endpoint, and `steps` run in order for every exchange. In a project
+created by `camel new`, place route files under `routes/` and run `camel run`.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,15 @@
+# Introduction
+
+rust-camel is a Rust-native integration framework for routing messages between
+timers, APIs, files, brokers, databases, and other systems. Routes may be
+authored with a fluent Rust builder or a declarative YAML DSL.
+
+The framework is inspired by Apache Camel's routing model, but is not a
+drop-in implementation. Its data plane composes processors and producers as
+Tower services, while its control plane manages components, endpoints,
+consumers, and route lifecycle.
+
+This guide is the home for concepts, tutorials, recipes, and operational
+guidance. Use the [API reference](api-reference.md) for Rust contracts and the
+[repository examples](https://github.com/kennycallado/rust-camel/tree/main/examples)
+for runnable integrations.

--- a/docs/src/operations/index.md
+++ b/docs/src/operations/index.md
@@ -1,0 +1,6 @@
+# Operations
+
+Operational deployments can use health endpoints, metrics, tracing, route
+supervision, configuration profiles, and container images. Consult the
+repository examples for current configurations while this section develops
+task-oriented deployment and troubleshooting recipes.

--- a/docs/src/yaml-dsl/index.md
+++ b/docs/src/yaml-dsl/index.md
@@ -1,0 +1,9 @@
+# YAML DSL
+
+YAML is the human-oriented declarative route format. It is parsed into the
+same route model used by embedded applications. Use snake_case for DSL keys,
+validate route files with the real parser, and keep reusable examples in the
+repository so guide snippets cannot silently drift.
+
+JSON is the canonical interchange format for SDKs and generators; YAML is the
+convenience format for people authoring routes.

--- a/examples/config-basic/routes/hello.yaml
+++ b/examples/config-basic/routes/hello.yaml
@@ -1,6 +1,8 @@
+# ANCHOR: first-route
 routes:
   - id: "hello-timer"
     from: "timer:tick?period=2000&repeatCount=3"
     steps:
       - log: "Hello from config-loaded route!"
       - to: "log:info"
+# ANCHOR_END: first-route

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -4,6 +4,7 @@ use camel_component_log::LogComponent;
 use camel_component_timer::TimerComponent;
 use camel_core::context::CamelContext;
 
+// ANCHOR: first-route
 #[tokio::main]
 async fn main() -> Result<(), CamelError> {
     tracing_subscriber::fmt()
@@ -29,3 +30,4 @@ async fn main() -> Result<(), CamelError> {
     ctx.stop().await?;
     Ok(())
 }
+// ANCHOR_END: first-route


### PR DESCRIPTION
### Motivation

- Provide a user-focused Guide separate from README and Rustdoc so narrative tasks (getting started, recipes, operations) live in an mdBook site.
- Reuse runnable examples as the authoritative source for code and YAML snippets to prevent drift between docs and code.
- Run documentation validation in CI and publish the rendered book via GitHub Pages to keep the site up to date automatically.

### Description

- Add mdBook skeleton and initial chapters under `docs/` including `book.toml` and `docs/src/SUMMARY.md` plus introductory and getting-started pages using mdBook `include` anchors. 
- Reuse real repository examples by adding `ANCHOR` regions to `examples/hello-world/src/main.rs` and `examples/config-basic/routes/hello.yaml` and referencing them from the guide chapters. 
- Add a small parser-backed test `crates/camel-dsl/tests/documentation_examples.rs` to assert the included YAML example parses with `camel_dsl::parse_yaml`. 
- Add CI validation workflow `.github/workflows/docs.yml` that runs `cargo doc`, doctests, example compilation, the YAML parser test, and `mdbook build`/`mdbook test`; and add a Pages deployment workflow `.github/workflows/pages.yml` that builds the book, uploads the artifact, and deploys it via the official Pages actions. 
- Update `README.md` to surface the new Guide vs API reference vs Examples, and update `.gitignore` to allow the `docs/` source files to be tracked.

### Testing

- Ran `cargo fmt --check --all` and `git diff --check` which passed locally. 
- Ran `cargo test -p camel-dsl --test documentation_examples` which passed and validates the YAML snippet parses with the real parser. 
- Ran `cargo check -p hello-world -p config-basic` which succeeded and confirms the referenced examples compile. 
- `mdbook build docs` and `mdbook test docs` are executed in the added CI workflow; a local `mdbook` install could not be performed in this environment due to network restrictions, so those steps are validated in CI rather than locally. 

Closes #34

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7225753e1083219142457740ba6b5b)